### PR TITLE
Adds a delay after pressing start and before starting the scanner

### DIFF
--- a/AkashaScanner/Ui/Partials/Scanner.razor
+++ b/AkashaScanner/Ui/Partials/Scanner.razor
@@ -32,7 +32,11 @@
 </div>
 <Modal Visible="@ShowModal">
     <div class="modal__content">
-        @if (Status == ScanStatus.Running)
+        @if (Status == ScanStatus.CountingDown) {
+            <div>Starting scan in @Countdown</div>
+            <Loading />
+        }
+        else if (Status == ScanStatus.Running)
         {
             <div>Scanning in progress</div>
             <Loading />
@@ -107,6 +111,7 @@
 
     private EditContext? Context;
     private ScanStatus Status { get; set; } = ScanStatus.Interrupted;
+    private int Countdown;
     private bool ShowModal { get; set; }
 
     private bool BtnEnabled => Enabled && ProcStatus.IsRunning();
@@ -115,6 +120,11 @@
     {
         if (Context != null && !Context.Validate()) return;
         ShowModal = true;
+        Status = ScanStatus.CountingDown;
+        for (Countdown = 3; Countdown > 0; Countdown--) {
+            StateHasChanged();
+            await Task.Delay(1000);
+        }
         Status = ScanStatus.Running;
         StateHasChanged();
         await Task.Run(() =>
@@ -135,6 +145,7 @@
     private enum ScanStatus
     {
         Idle,
+        CountingDown,
         Running,
         Canceling,
         Success,


### PR DESCRIPTION
Adds another state `CountingDown` to the Scanner UI between `Idle` and `Running` that displays a 3 second countdown before the scanner starts running.

The motivation is that sometimes my mouse moves a small bit when I left my hand off of it after pressing the "Start" button, which interrupts and cancels the scan. With the delay, users get a chance to get their hands off their mouse.

Demo:
![akasha-scanner-countdown](https://github.com/xenesty/AkashaScanner/assets/22552467/2f726298-cc39-4df5-a061-10f82c493cbb)
